### PR TITLE
Add TimeCop Gem to test for 24 hour functionality

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -12,7 +12,7 @@ class LinksController < ApplicationController
   end
 
   def index
-    @links = Link.order(submission_count: :desc).limit(10)
+    @links = Link.where(updated_at: (Time.now - 24.hours)..Time.now).order(submission_count: :desc).limit(10)
 
   end
 

--- a/spec/features/links_index_spec.rb
+++ b/spec/features/links_index_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe "Show Links" do
     expect(page).to have_selector("li", count: 10)
   end
 
-  
+  it 'shows links from within 24 hours of update' do
+    Timecop.freeze(Date.today - 2) do
+      Link.create(url: "http://test.com")
+    end
+
+    Link.create(url: "http://www.google.com")
+
+    visit '/'
+
+    expect(page).to have_selector("li", count: 1)
+  end
 
 end


### PR DESCRIPTION
Time Cop is a gem that can help freeze time and allow to test for the 24 hour boundary.